### PR TITLE
Fixed usage of GitLab API in GitLabAdapter

### DIFF
--- a/src/main/i5/las2peer/services/codeGenerationService/adapters/GitLabAdapter.java
+++ b/src/main/i5/las2peer/services/codeGenerationService/adapters/GitLabAdapter.java
@@ -208,7 +208,7 @@ public class GitLabAdapter extends BaseGitHostAdapter{
 		}
 		
 		if (id != -1) {
-			// example: http://ginkgo.informatik.rwth-aachen.de:4080/api/v3/projects/2
+			// example: http://ginkgo.informatik.rwth-aachen.de:4080/api/v4/projects/2
 			deleteResource(baseURL + "api/v4/" + "projects/" + id);
 		}
 		

--- a/src/main/i5/las2peer/services/codeGenerationService/adapters/GitLabAdapter.java
+++ b/src/main/i5/las2peer/services/codeGenerationService/adapters/GitLabAdapter.java
@@ -199,7 +199,7 @@ public class GitLabAdapter extends BaseGitHostAdapter{
 	public void deleteRepo(String name) throws GitHostException {
 		long id = -1;
 		try {
-		JSONArray arr = getJSONArray(baseURL + "api/v3/" + "groups/" + this.gitOrganization + "/projects/");
+		JSONArray arr = getJSONArray(baseURL + "api/v4/" + "groups/" + this.gitOrganization + "/projects/");
 		// We need to get the id of the repo, search for it
 		for(Object obj : arr){
 			if (((JSONObject) obj).get("name").toString().equalsIgnoreCase(name)) {
@@ -209,7 +209,7 @@ public class GitLabAdapter extends BaseGitHostAdapter{
 		
 		if (id != -1) {
 			// example: http://ginkgo.informatik.rwth-aachen.de:4080/api/v3/projects/2
-			deleteResource(baseURL + "api/v3/" + "projects/" + id);
+			deleteResource(baseURL + "api/v4/" + "projects/" + id);
 		}
 		
 		}catch (ParseException e) {
@@ -225,14 +225,15 @@ public class GitLabAdapter extends BaseGitHostAdapter{
 	@SuppressWarnings("unchecked")
 	public void createRepo(String name, String description) throws GitHostException {
 		//Get namespace id for group
-		JSONObject result = getJSONObject(baseURL + "api/v3/" + "groups/" + this.getGitOrganization());
+		JSONObject result = getJSONObject(baseURL + "api/v4/" + "groups/" + this.getGitOrganization());
 		long id = (long) result.get("id");
 		//Create json object representing new repo
 		JSONObject obj = new JSONObject();
 		obj.put("name", name);
 		obj.put("description", description);
 		obj.put("namespace_id", id);
-		createResource(baseURL + "api/v3/" + "projects", obj);
+		obj.put("visibility", "public");
+		createResource(baseURL + "api/v4/" + "projects", obj);
 	}
 	
 }

--- a/src/main/i5/las2peer/services/codeGenerationService/adapters/GitLabAdapter.java
+++ b/src/main/i5/las2peer/services/codeGenerationService/adapters/GitLabAdapter.java
@@ -232,7 +232,6 @@ public class GitLabAdapter extends BaseGitHostAdapter{
 		obj.put("name", name);
 		obj.put("description", description);
 		obj.put("namespace_id", id);
-		obj.put("visibility", "public");
 		createResource(baseURL + "api/v4/" + "projects", obj);
 	}
 	


### PR DESCRIPTION
The GitLabAdapter still used v3 of the GitLab API which was removed in GitLab 11.0.
Now it uses v4.